### PR TITLE
RoutingUseCase をスリム化

### DIFF
--- a/Assets/Scripts/CAFU/Routing/Data/DataStore/SceneDataStore.cs
+++ b/Assets/Scripts/CAFU/Routing/Data/DataStore/SceneDataStore.cs
@@ -2,12 +2,13 @@
 using CAFU.Core.Data;
 using CAFU.Routing.Data.Entity;
 using UniRx;
+using UnityEngine.SceneManagement;
 
 namespace CAFU.Routing.Data.DataStore {
 
     public interface ISceneDataStore : IDataStore {
 
-        IObservable<SceneEntity> LoadSceneAsObservable(string sceneName, UnityEngine.SceneManagement.LoadSceneMode loadSceneMode);
+        IObservable<SceneEntity> LoadSceneAsObservable(string sceneName, LoadSceneMode loadSceneMode);
 
         IObservable<SceneEntity> UnloadSceneAsObservable(string sceneName);
 
@@ -18,7 +19,7 @@ namespace CAFU.Routing.Data.DataStore {
 
         private Dictionary<string, SceneEntity> sceneEntityCacheMap;
 
-        public Dictionary<string, SceneEntity> SceneEntityCacheMap {
+        private Dictionary<string, SceneEntity> SceneEntityCacheMap {
             get {
                 if (this.sceneEntityCacheMap == default(Dictionary<string, SceneEntity>)) {
                     this.sceneEntityCacheMap = new Dictionary<string, SceneEntity>();
@@ -30,16 +31,16 @@ namespace CAFU.Routing.Data.DataStore {
             }
         }
 
-        public IObservable<SceneEntity> LoadSceneAsObservable(string sceneName, UnityEngine.SceneManagement.LoadSceneMode loadSceneMode) {
+        public IObservable<SceneEntity> LoadSceneAsObservable(string sceneName, LoadSceneMode loadSceneMode) {
             if (this.SceneEntityCacheMap.ContainsKey(sceneName)) {
                 return Observable.Throw<SceneEntity>(new System.ArgumentException(string.Format("Scene '{0}' already has loaded.", sceneName)));
             }
-            return UnityEngine.SceneManagement.SceneManager.LoadSceneAsync(sceneName, loadSceneMode)
+            return SceneManager.LoadSceneAsync(sceneName, loadSceneMode)
                 .AsObservable()
                 .Select(
                     (_) => {
                         SceneEntity sceneEntity = new SceneEntity() {
-                            UnityScene = UnityEngine.SceneManagement.SceneManager.GetSceneByName(sceneName)
+                            UnityScene = SceneManager.GetSceneByName(sceneName)
                         };
                         this.SceneEntityCacheMap[sceneName] = sceneEntity;
                         return sceneEntity;
@@ -55,10 +56,10 @@ namespace CAFU.Routing.Data.DataStore {
                 }
                 // エディタ実行の場合のみ、初期シーンの直接読み込みを考慮して値を疑似構築する
                 this.SceneEntityCacheMap[sceneName] = new SceneEntity() {
-                    UnityScene = UnityEngine.SceneManagement.SceneManager.GetSceneByName(sceneName),
+                    UnityScene = SceneManager.GetSceneByName(sceneName),
                 };
             }
-            return UnityEngine.SceneManagement.SceneManager.UnloadSceneAsync(sceneName)
+            return SceneManager.UnloadSceneAsync(sceneName)
                 .AsObservable()
                 .Select(
                     (_) => {

--- a/Assets/Scripts/CAFU/Routing/Data/DataStore/SceneDataStore.cs
+++ b/Assets/Scripts/CAFU/Routing/Data/DataStore/SceneDataStore.cs
@@ -40,6 +40,7 @@ namespace CAFU.Routing.Data.DataStore {
                 .Select(
                     (_) => {
                         SceneEntity sceneEntity = new SceneEntity() {
+                            Name = sceneName,
                             UnityScene = SceneManager.GetSceneByName(sceneName)
                         };
                         this.SceneEntityCacheMap[sceneName] = sceneEntity;
@@ -56,6 +57,7 @@ namespace CAFU.Routing.Data.DataStore {
                 }
                 // エディタ実行の場合のみ、初期シーンの直接読み込みを考慮して値を疑似構築する
                 this.SceneEntityCacheMap[sceneName] = new SceneEntity() {
+                    Name = sceneName,
                     UnityScene = SceneManager.GetSceneByName(sceneName),
                 };
             }

--- a/Assets/Scripts/CAFU/Routing/Data/Entity/SceneEntity.cs
+++ b/Assets/Scripts/CAFU/Routing/Data/Entity/SceneEntity.cs
@@ -5,6 +5,12 @@ namespace CAFU.Routing.Data.Entity {
 
     public class SceneEntity : IEntity {
 
+        /// <summary>
+        /// シーン名
+        /// </summary>
+        /// <remarks>UnityScene との二重管理になるが、Unload 時に Unload した Scene の構造体を拾えないため、やむを得ず…。</remarks>
+        public string Name { get; set; }
+
         public UnityEngine.SceneManagement.Scene UnityScene { get; set; }
 
     }

--- a/Assets/Scripts/CAFU/Routing/Domain/Translator/RoutingTranslator.cs
+++ b/Assets/Scripts/CAFU/Routing/Domain/Translator/RoutingTranslator.cs
@@ -18,9 +18,10 @@ namespace CAFU.Routing.Domain.Translator {
         }
 
         public IObservable<SceneModel> TranslateAsync(SceneEntity entity) {
-            SceneModel sceneModel = new SceneModel();
+            SceneModel sceneModel = new SceneModel {
+                Name = entity.Name,
+            };
             if (entity.UnityScene.IsValid()) {
-                sceneModel.Name = entity.UnityScene.name;
                 sceneModel.ViewController = entity.UnityScene
                     .GetRootGameObjects()
                     .ToList()

--- a/Assets/Scripts/CAFU/Routing/Domain/UseCase/RoutingUseCase.cs
+++ b/Assets/Scripts/CAFU/Routing/Domain/UseCase/RoutingUseCase.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using CAFU.Core.Domain;
+﻿using CAFU.Core.Domain;
 using CAFU.Routing.Domain.Model;
 using CAFU.Routing.Domain.Repository;
 using CAFU.Routing.Domain.Translator;
@@ -11,6 +10,8 @@ namespace CAFU.Routing.Domain.UseCase {
     public class RoutingUseCase : IUseCaseAsSingleton, IUseCaseBuilder {
 
         public void Build() {
+            this.LoadSceneSubject = new Subject<SceneModel>();
+            this.UnloadSceneSubject = new Subject<SceneModel>();
             this.RoutingRepository = new RoutingRepository();
             this.RoutingTranslator = new RoutingTranslator();
         }
@@ -19,38 +20,9 @@ namespace CAFU.Routing.Domain.UseCase {
 
         private RoutingTranslator RoutingTranslator { get; set; }
 
-        private Dictionary<string, SceneModel> sceneModelMap;
+        private Subject<SceneModel> LoadSceneSubject { get; set; }
 
-        private Dictionary<string, SceneModel> SceneModelMap {
-            get {
-                if (this.sceneModelMap == default(Dictionary<string, SceneModel>)) {
-                    this.sceneModelMap = new Dictionary<string, SceneModel>();
-                }
-                return this.sceneModelMap;
-            }
-        }
-
-        private Dictionary<string, Subject<SceneModel>> onLoadSceneSubjectMap;
-
-        private Dictionary<string, Subject<SceneModel>> OnLoadSceneSubjectMap {
-            get {
-                if (this.onLoadSceneSubjectMap == default(Dictionary<string, Subject<SceneModel>>)) {
-                    this.onLoadSceneSubjectMap = new Dictionary<string, Subject<SceneModel>>();
-                }
-                return this.onLoadSceneSubjectMap;
-            }
-        }
-
-        private Dictionary<string, Subject<SceneModel>> onUnloadSceneSubjectMap;
-
-        private Dictionary<string, Subject<SceneModel>> OnUnloadSceneSubjectMap {
-            get {
-                if (this.onUnloadSceneSubjectMap == default(Dictionary<string, Subject<SceneModel>>)) {
-                    this.onUnloadSceneSubjectMap = new Dictionary<string, Subject<SceneModel>>();
-                }
-                return this.onUnloadSceneSubjectMap;
-            }
-        }
+        private Subject<SceneModel> UnloadSceneSubject { get; set; }
 
         public void LoadScene(string sceneName, LoadSceneMode loadSceneMode) {
             this.LoadSceneAsObservable(sceneName, loadSceneMode).Subscribe();
@@ -60,63 +32,48 @@ namespace CAFU.Routing.Domain.UseCase {
             this.UnloadSceneAsObservable(sceneName).Subscribe();
         }
 
-        public bool HasSceneLoaded(string sceneName) {
-            return this.SceneModelMap.ContainsKey(sceneName) && this.SceneModelMap[sceneName] != default(SceneModel);
-        }
-
-        private IObservable<SceneModel> LoadSceneAsObservable(string sceneName, LoadSceneMode loadSceneMode) {
+        public IObservable<SceneModel> LoadSceneAsObservable(string sceneName, LoadSceneMode loadSceneMode) {
             IObservable<SceneModel> stream = this.RoutingRepository
                 .LoadSceneAsObservable(sceneName, loadSceneMode)
                 .SelectMany(x => this.RoutingTranslator.TranslateAsync(x))
                 .Share();
             // OnComplete を流してしまうと、Subject が閉じてしまうので OnNext, OnError のみを流す
-            stream.Subscribe(
-                this.GetLoadSceneSubject(sceneName).OnNext,
-                this.GetLoadSceneSubject(sceneName).OnError
-            );
+            stream
+                .Subscribe(
+                    this.LoadSceneSubject.OnNext,
+                    this.LoadSceneSubject.OnError
+                );
             return stream;
         }
 
-        private IObservable<SceneModel> UnloadSceneAsObservable(string sceneName) {
+        public IObservable<SceneModel> UnloadSceneAsObservable(string sceneName) {
             IObservable<SceneModel> stream = this.RoutingRepository
                 .UnloadSceneAsObservable(sceneName)
                 .SelectMany(x => this.RoutingTranslator.TranslateAsync(x))
                 .Share();
             // OnComplete を流してしまうと、Subject が閉じてしまうので OnNext, OnError のみを流す
-            stream.Subscribe(
-                this.GetUnloadSceneSubject(sceneName).OnNext,
-                this.GetUnloadSceneSubject(sceneName).OnError
-            );
+            stream
+                .Subscribe(
+                    this.UnloadSceneSubject.OnNext,
+                    this.UnloadSceneSubject.OnError
+                );
             return stream;
         }
 
+        public IObservable<SceneModel> OnLoadSceneAsObservable() {
+            return this.LoadSceneSubject.AsObservable();
+        }
+
         public IObservable<SceneModel> OnLoadSceneAsObservable(string sceneName) {
-            return this.GetLoadSceneSubject(sceneName).AsObservable();
+            return this.OnLoadSceneAsObservable().Where(x => x.Name == sceneName).AsObservable();
+        }
+
+        public IObservable<SceneModel> OnUnloadSceneAsObservable() {
+            return this.UnloadSceneSubject.AsObservable();
         }
 
         public IObservable<SceneModel> OnUnloadSceneAsObservable(string sceneName) {
-            return this.GetUnloadSceneSubject(sceneName).AsObservable();
-        }
-
-        private Subject<SceneModel> GetLoadSceneSubject(string sceneName) {
-            if (!this.OnLoadSceneSubjectMap.ContainsKey(sceneName)) {
-                this.OnLoadSceneSubjectMap[sceneName] = new Subject<SceneModel>();
-                this.OnLoadSceneSubjectMap[sceneName]
-                    .Where(x => !string.IsNullOrEmpty(x.Name) && !this.SceneModelMap.ContainsKey(x.Name))
-                    .Subscribe(x => this.SceneModelMap[x.Name] = x);
-            }
-            return this.OnLoadSceneSubjectMap[sceneName];
-        }
-
-        private Subject<SceneModel> GetUnloadSceneSubject(string sceneName) {
-            if (!this.OnUnloadSceneSubjectMap.ContainsKey(sceneName)) {
-                this.OnUnloadSceneSubjectMap[sceneName] = new Subject<SceneModel>();
-                // XXX: 本来はストリームに流れてくる値を使うべきだが、 Unload の場合は値が入らないのでラムダ式キャプチャする
-                this.OnUnloadSceneSubjectMap[sceneName]
-                    .Where(_ => !string.IsNullOrEmpty(sceneName) && this.SceneModelMap.ContainsKey(sceneName))
-                    .Subscribe(_ => this.SceneModelMap.Remove(sceneName));
-            }
-            return this.OnUnloadSceneSubjectMap[sceneName];
+            return this.OnUnloadSceneAsObservable().Where(x => x.Name == sceneName).AsObservable();
         }
 
     }


### PR DESCRIPTION
* LoadScene/UnloadScene 時に確実にシーン名がストリームされるようにする
* OnLoadSceneAsObservable/OnUnloadSceneAsObservable をシーン名でフィルタするコトで実装を簡素化する