### PR TITLE
RootGameObjects にアクセス出来るようにする

### DIFF
--- a/Assets/Scripts/CAFU/Routing/Domain/Model/SceneModel.cs
+++ b/Assets/Scripts/CAFU/Routing/Domain/Model/SceneModel.cs
@@ -1,5 +1,6 @@
 ﻿using CAFU.Core.Domain.Model;
 using CAFU.Core.Presentation.View;
+using UnityEngine;
 
 namespace CAFU.Routing.Domain.Model {
 
@@ -8,6 +9,8 @@ namespace CAFU.Routing.Domain.Model {
         public string Name { get; set; }
 
         public IController Controller { get; set; }
+
+        public GameObject[] RootGameObjects { get; set; }
 
     }
 

--- a/Assets/Scripts/CAFU/Routing/Domain/Translator/RoutingTranslator.cs
+++ b/Assets/Scripts/CAFU/Routing/Domain/Translator/RoutingTranslator.cs
@@ -18,6 +18,7 @@ namespace CAFU.Routing.Domain.Translator {
                 Name = entity.Name,
             };
             if (entity.UnityScene.IsValid()) {
+                sceneModel.RootGameObjects = entity.UnityScene.GetRootGameObjects();
                 sceneModel.Controller = entity.UnityScene
                     .GetRootGameObjects()
                     .ToList()


### PR DESCRIPTION
* 極稀に、遷移先のシーンの Camera などにアクセスしたくなるケースがあるので、アクセス可能にしておく
