### PR TITLE
画面遷移先の Scene に Controller コンポーネントがアタッチされていても、Exception が Throw されてしまうバグに対応する

### DIFF
--- a/Assets/Scripts/Domain/Translator/RoutingTranslator.cs
+++ b/Assets/Scripts/Domain/Translator/RoutingTranslator.cs
@@ -31,9 +31,7 @@ namespace CAFU.Routing.Domain.Translator
                     .GetComponent<IController>();
             }
 
-            return sceneModel.Controller == default(IController)
-                ? Observable.Throw<SceneModel>(new NullReferenceException($"The component what implements `CAFU.Core.Presentation.View.IController` does not found in destination scene. Please check `{entity.Name}` scenes to see if `Controller` component is attached."))
-                : Observable.Return(sceneModel);
+            return Observable.Return(sceneModel);
         }
     }
 }

--- a/Assets/Scripts/Domain/Translator/RoutingTranslator.cs
+++ b/Assets/Scripts/Domain/Translator/RoutingTranslator.cs
@@ -22,14 +22,17 @@ namespace CAFU.Routing.Domain.Translator
             {
                 Name = entity.Name,
             };
-            if (entity.UnityScene.IsValid())
+
+            if (!entity.UnityScene.IsValid())
             {
-                sceneModel.RootGameObjects = entity.UnityScene.GetRootGameObjects();
-                sceneModel.Controller = entity.UnityScene
-                    .GetRootGameObjects()
-                    .FirstOrDefault(x => x.GetComponent<IController>() != default(IController))?
-                    .GetComponent<IController>();
+                return Observable.Return(sceneModel);
             }
+
+            sceneModel.RootGameObjects = entity.UnityScene.GetRootGameObjects();
+            sceneModel.Controller = entity.UnityScene
+                .GetRootGameObjects()
+                .FirstOrDefault(x => x.GetComponent<IController>() != default(IController))?
+                .GetComponent<IController>();
 
             return sceneModel.Controller == default(IController)
                 ? Observable.Throw<SceneModel>(new NullReferenceException($"The component what implements `CAFU.Core.Presentation.View.IController` does not found in destination scene. Please check `{entity.Name}` scenes to see if `Controller` component is attached."))

--- a/Assets/Scripts/Domain/Translator/RoutingTranslator.cs
+++ b/Assets/Scripts/Domain/Translator/RoutingTranslator.cs
@@ -22,17 +22,14 @@ namespace CAFU.Routing.Domain.Translator
             {
                 Name = entity.Name,
             };
-
-            if (!entity.UnityScene.IsValid())
+            if (entity.UnityScene.IsValid())
             {
-                return Observable.Return(sceneModel);
+                sceneModel.RootGameObjects = entity.UnityScene.GetRootGameObjects();
+                sceneModel.Controller = entity.UnityScene
+                    .GetRootGameObjects()
+                    .FirstOrDefault(x => x.GetComponent<IController>() != default(IController))?
+                    .GetComponent<IController>();
             }
-
-            sceneModel.RootGameObjects = entity.UnityScene.GetRootGameObjects();
-            sceneModel.Controller = entity.UnityScene
-                .GetRootGameObjects()
-                .FirstOrDefault(x => x.GetComponent<IController>() != default(IController))?
-                .GetComponent<IController>();
 
             return sceneModel.Controller == default(IController)
                 ? Observable.Throw<SceneModel>(new NullReferenceException($"The component what implements `CAFU.Core.Presentation.View.IController` does not found in destination scene. Please check `{entity.Name}` scenes to see if `Controller` component is attached."))

--- a/Assets/Scripts/Domain/UseCase/RoutingUseCase.cs
+++ b/Assets/Scripts/Domain/UseCase/RoutingUseCase.cs
@@ -114,7 +114,10 @@ namespace CAFU.Routing.Domain.UseCase
                         {
                             LoadSceneSubject.OnError(new NullReferenceException($"The component what implements `CAFU.Core.Presentation.View.IController` does not found in destination scene. Please check `{x.Name}` scenes to see if `Controller` component is attached."));
                         }
-                        LoadSceneSubject.OnNext(x);
+                        else
+                        {
+                            LoadSceneSubject.OnNext(x);
+                        }
                     },
                     LoadSceneSubject.OnError
                 );

--- a/Assets/Scripts/Domain/UseCase/RoutingUseCase.cs
+++ b/Assets/Scripts/Domain/UseCase/RoutingUseCase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using CAFU.Core.Domain.UseCase;
+using CAFU.Core.Presentation.View;
 using CAFU.Routing.Domain.Model;
 using CAFU.Routing.Domain.Repository;
 using CAFU.Routing.Domain.Translator;
@@ -107,7 +108,14 @@ namespace CAFU.Routing.Domain.UseCase
             // OnComplete を流してしまうと、Subject が閉じてしまうので OnNext, OnError のみを流す
             stream
                 .Subscribe(
-                    LoadSceneSubject.OnNext,
+                    (x) =>
+                    {
+                        if (x.Controller == default(IController))
+                        {
+                            LoadSceneSubject.OnError(new NullReferenceException($"The component what implements `CAFU.Core.Presentation.View.IController` does not found in destination scene. Please check `{x.Name}` scenes to see if `Controller` component is attached."));
+                        }
+                        LoadSceneSubject.OnNext(x);
+                    },
                     LoadSceneSubject.OnError
                 );
             return stream;


### PR DESCRIPTION
## 💀 問題
* 画面遷移先の Scene に Controller コンポーネントがアタッチされていても、Unload Scene の延長で、Exception が Throw されてしまう

## 😎 やること
* #25 で対応した処理の一部を変更して、画面遷移先の Scene に Controller コンポーネントが付いてないときは Exception を Throw し、付いているときは正しく遷移出来るようにする