### PR TITLE
Loosen check when unload scene

### DIFF
--- a/Assets/Scripts/Data/DataStore/SceneDataStore.cs
+++ b/Assets/Scripts/Data/DataStore/SceneDataStore.cs
@@ -49,10 +49,10 @@ namespace CAFU.Routing.Data.DataStore
         {
             if (!SceneEntityCacheMap.ContainsKey(sceneName))
             {
-                // エディタ実行でない場合には「読み込まれていない」旨を Exception として Throw する
-                if (!Application.isEditor)
+                // エディタの場合に「読み込まれていない」旨を警告する
+                if (Application.isEditor)
                 {
-                    return Observable.Throw<SceneEntity>(new ArgumentException($"Scene '{sceneName}' has not loaded yet."));
+                    Debug.LogWarning($"Scene '{sceneName}' has not loaded yet.");
                 }
 
                 // エディタ実行の場合のみ、初期シーンの直接読み込みを考慮して値を疑似構築する


### PR DESCRIPTION
## What

* Even if the scene has not yet been loaded, do not throw an exception at the unload scene

## Why

* Even when reading without using RoutingUseCase make it possible to proceed without exception